### PR TITLE
default with_imgcodec_pfm to True

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -197,7 +197,7 @@ class OpenCVConan(ConanFile):
         "with_gdal": False,
         "with_gdcm": False,
         "with_imgcodec_hdr": False,
-        "with_imgcodec_pfm": False,
+        "with_imgcodec_pfm": True,
         "with_imgcodec_pxm": False,
         "with_imgcodec_sunraster": False,
         "with_msmf": True,


### PR DESCRIPTION
The OpenCV projects sets the default of this value to true, there is no reason to change this. If anything, not enabling this by default can lead to unexpected fails at runtime which can be hard to debug.


### Summary
Changes to recipe:  **lib/opencv**

#### Motivation
The OpenCV projects sets the default of this value to true, there is no reason to change this.
If anything, not enabling this by default can lead to unexpected fails at runtime which can be hard to debug.

#### Details
Changing the default value for option `with_imgcodec_pfm` from `False` to `True`.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
